### PR TITLE
sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ build:
 	$(call break, b )
 	$(call success, Compressed $(BINARY_NAME) )
 
-
 # Build the binary using the install script
 build-dev:
 	@if [ -f $(BINARY_NAME) ]; then rm $(BINARY_NAME); fi
@@ -60,6 +59,14 @@ clean:
 	$(call break, b )
 	$(call success, Cleaned up build artifacts)
 
+# Run tests
+test:
+	$(call log, Running tests)
+	$(call break, b )
+	@go test ./... -v || exit 1
+	$(call break, b )
+	$(call success, Tests completed successfully)
+
 # Display this help message
 help:
 	$(call log, $(APP_NAME) Makefile )
@@ -72,6 +79,7 @@ help:
 	$(call log,   make build-dev  - Build the binary without compressing it)
 	$(call log,   make install    - Install the binary and configure environment)
 	$(call log,   make clean      - Clean up build artifacts)
+	$(call log,   make test       - Run tests)
 	$(call log,   make help       - Display this help message)
 	$(call break, b )
 	$(call log, Usage with arguments: )

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ A powerful and user-friendly Command Line Interface (CLI) for [Kubero](https://g
 - **Pipeline Integration:** Seamlessly integrate CI/CD pipelines.
 - **User-Friendly Commands:** Intuitive CLI commands for efficient workflows.
 - **Dashboard Access:** Easy access to the Kubero dashboard for monitoring.
- 
+- **Automated RSA Certificate Generation:** Securely generate encrypted RSA certificates with random passwords stored in a keyring.
+- **Separate Test Flow:** Handle test logic separately from the core logic for better modularity.
+
 <br/>
 
 ---

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Show your configuration",
+	/*
+			Long: `A longer description that spans multiple lines and likely contains examples
+		and usage of using your command. For example:
+
+		Cobra is a CLI library for Go that empowers applications.
+		This application is a tool to generate the needed files
+		to quickly create a Cobra application.`,
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Println("config called")
+			},
+	*/
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -1,0 +1,282 @@
+package create
+
+import (
+	"fmt"
+	"kubero/pkg/kuberoApi"
+	"os"
+	"strconv"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/i582/cfmt/cmd/cfmt"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:     "create",
+	Aliases: []string{"cr", "add", "new"},
+	Short:   "Create a new pipeline and/or app",
+	Long:    `Initiate a new pipeline and app in your current repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		createPipelineAndApp()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+	createCmd.PersistentFlags().StringVarP(&pipelineName, "pipeline", "p", "", "name of the pipeline")
+}
+
+func createPipelineAndApp() {
+	createPipelineAndApp := promptLine("Create a new pipeline", "[y,n]", "y")
+	if createPipelineAndApp == "y" {
+		createPipeline()
+	}
+
+	pipelinesList := getAllLocalPipelines()
+	ensurePipelineIsSet(pipelinesList)
+	ensureStageNameIsSet()
+	ensureAppNameIsSet()
+	createApp()
+}
+
+func appForm() kuberoApi.AppCRD {
+
+	var appCRD kuberoApi.AppCRD
+
+	appconfig := loadAppConfig(pipelineName, stageName, appName)
+	pipelineConfig := loadPipelineConfig(pipelineName)
+
+	appCRD.APIVersion = "application.kubero.dev/v1alpha1"
+	appCRD.Kind = "KuberoApp"
+
+	appCRD.Spec.Name = appName
+	appCRD.Spec.Pipeline = pipelineName
+	appCRD.Spec.Phase = stageName
+
+	appCRD.Spec.Domain = promptLine("Domain", "", appconfig.GetString("spec.domain"))
+
+	unmarshalKeyErr := pipelineConfig.UnmarshalKey("spec.git.repository", &appCRD.Spec.Gitrepo)
+	if unmarshalKeyErr != nil {
+		fmt.Println(unmarshalKeyErr)
+		return kuberoApi.AppCRD{}
+	}
+
+	gitURL := pipelineConfig.GetString("spec.git.repository.sshurl")
+	appCRD.Spec.Branch = promptLine("Branch", gitURL+":", appconfig.GetString("spec.branch"))
+
+	appCRD.Spec.Buildpack = pipelineConfig.GetString("spec.buildpack.name")
+
+	autodeployDefault := "n"
+	if !appconfig.GetBool("spec.autodeploy") {
+		autodeployDefault = "y"
+	}
+	autodeploy := promptLine("Autodeploy", "[y,n]", autodeployDefault)
+	if autodeploy == "Y" {
+		appCRD.Spec.Autodeploy = true
+	} else {
+		appCRD.Spec.Autodeploy = false
+	}
+
+	envCount, _ := strconv.Atoi(promptLine("Number of Env Vars", "", "0"))
+	appCRD.Spec.EnvVars = []string{}
+	for i := 0; i < envCount; i++ {
+		appCRD.Spec.EnvVars = append(appCRD.Spec.EnvVars, promptLine("Env Var", "", ""))
+	}
+
+	appCRD.Spec.Image.ContainerPort, _ = strconv.Atoi(promptLine("Container Port", "8080", appconfig.GetString("spec.image.containerport")))
+
+	appCRD.Spec.Web = kuberoApi.Web{}
+	appCRD.Spec.Web.ReplicaCount, _ = strconv.Atoi(promptLine("Web Pods", "1", appconfig.GetString("spec.web.replicacount")))
+
+	appCRD.Spec.Worker = kuberoApi.Worker{}
+	appCRD.Spec.Worker.ReplicaCount, _ = strconv.Atoi(promptLine("Worker Pods", "0", appconfig.GetString("spec.worker.replicacount")))
+
+	return appCRD
+}
+
+func createApp() {
+
+	appCRD := appForm()
+
+	writeAppYaml(appCRD)
+
+	_, _ = cfmt.Println("\n\n{{Created appCRD.yaml}}::green")
+}
+
+func writeAppYaml(appCRD kuberoApi.AppCRD) {
+	// write pipeline.yaml
+	yamlData, err := yaml.Marshal(&appCRD)
+
+	if err != nil || appCRD.Spec.Name == "" {
+		panic("Unable to write data into the file")
+	}
+
+	fileName := ".kubero/" + appCRD.Spec.Pipeline + "/" + appCRD.Spec.Phase + "/" + appCRD.Spec.Name + ".yaml"
+
+	err = os.WriteFile(fileName, yamlData, 0644)
+	if err != nil {
+		panic("Unable to write data into the file")
+	}
+}
+
+func createPipeline() kuberoApi.PipelineCRD {
+
+	loadConfigs(pipelineName)
+
+	loadRepositories()
+	loadContexts()
+	loadBuildpacks()
+	pipelineCRD := pipelinesForm()
+
+	writePipelineYaml(pipelineCRD)
+
+	_, _ = cfmt.Println("\n\n{{Created pipeline.yaml}}::green")
+	_, _ = cfmt.Println(pipelineName)
+
+	return pipelineCRD
+}
+
+func writePipelineYaml(pipeline kuberoApi.PipelineCRD) {
+	basePath := "/.kubero/" //TODO Make it dynamic
+
+	gitdir := getGitdir()
+	dir := gitdir + basePath + pipelineName
+	err := os.MkdirAll(dir, 0755)
+
+	if err != nil {
+		fmt.Println(err)
+		panic("Unable to create directory")
+	}
+
+	yamlData, err := yaml.Marshal(&pipeline)
+
+	// iterate over phases to create the directory
+	for _, phase := range pipeline.Spec.Phases {
+		if phase.Enabled {
+			err := os.MkdirAll(dir+"/"+phase.Name, 0755)
+			if err != nil {
+				fmt.Println(err)
+				panic("Unable to create directory")
+			}
+		}
+	}
+
+	if err != nil {
+		fmt.Printf("Error while Marshaling. %v", err)
+	}
+	//fmt.Println(string(yamlData))
+
+	fileName := dir + "/pipeline.yaml"
+	err = os.WriteFile(fileName, yamlData, 0644)
+	if err != nil {
+		panic("Unable to write data into the file")
+	}
+}
+
+func pipelinesForm() kuberoApi.PipelineCRD {
+
+	var pipelineCRD kuberoApi.PipelineCRD
+
+	if pipelineName == "" {
+		pipelineName = promptLine("Define a PipelineName name", "", "")
+	}
+	pipelineCRD.Spec.Name = pipelineName
+
+	pipelineCRD.APIVersion = "application.kubero.dev/v1alpha1"
+	pipelineCRD.Kind = "KuberoPipeline"
+
+	fmt.Println("")
+	prompt := &survey.Select{
+		Message: "Select a buildpack",
+		Options: buildPacksSimpleList,
+	}
+	askOneErr := survey.AskOne(prompt, &pipelineCRD.Spec.Buildpack.Name)
+	if askOneErr != nil {
+		fmt.Println(askOneErr.Error())
+		return kuberoApi.PipelineCRD{}
+	}
+
+	domain := pipelineConfig.GetString("spec.domain")
+	pipelineCRD.Spec.Domain = promptLine("FQDN Domain ", "", domain)
+
+	// those fields are deprecated and may be removed in the future
+	pipelineCRD.Spec.DockerImage = ""
+	pipelineCRD.Spec.DeploymentStrategy = "git"
+
+	gitconnection := promptLine("Connect pipeline to a Git repository (GitOps)", "[y,n]", "n")
+
+	contextDefault := contextSimpleList[0]
+	if gitconnection == "y" {
+		gitProvider := pipelineConfig.GetString("spec.git.repository.provider")
+		pipelineCRD.Spec.Git.Repository.Provider = promptLine("Repository Provider", fmt.Sprint(repoSimpleList), gitProvider)
+
+		gitURL := pipelineConfig.GetString("spec.git.repository.sshurl")
+		pipelineCRD.Spec.Git.Repository.SshUrl = promptLine("Repository URL", "["+getGitRemote()+"]", gitURL)
+
+		phaseReview := promptLine("enable reviewapps", "[y,n]", "n")
+		if phaseReview == "y" {
+			pipelineCRD.Spec.ReviewApps = true
+			pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+				Name:    "review",
+				Enabled: true,
+				Context: promptLine("Context for reviewapps", fmt.Sprint(contextSimpleList), contextDefault),
+			})
+		} else {
+			pipelineCRD.Spec.ReviewApps = false
+			pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+				Name:    "review",
+				Enabled: false,
+				Context: "",
+			})
+		}
+	}
+
+	phaseTest := promptLine("enable test", "[y,n]", "n")
+	if phaseTest == "y" {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "test",
+			Enabled: true,
+			Context: promptLine("Context for test", fmt.Sprint(contextSimpleList), contextDefault),
+		})
+	} else {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "test",
+			Enabled: false,
+			Context: "",
+		})
+	}
+
+	phaseStage := promptLine("enable stage", "[y,n]", "n")
+	if phaseStage == "y" {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "stage",
+			Enabled: true,
+			Context: promptLine("Context for stage", fmt.Sprint(contextSimpleList), contextDefault),
+		})
+	} else {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "stage",
+			Enabled: false,
+			Context: "",
+		})
+	}
+
+	phaseProduction := promptLine("enable production", "[y,n]", "y")
+	if phaseProduction != "n" {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "production",
+			Enabled: true,
+			Context: promptLine("Context for production ", fmt.Sprint(contextSimpleList), contextDefault),
+		})
+	} else {
+		pipelineCRD.Spec.Phases = append(pipelineCRD.Spec.Phases, kuberoApi.Phase{
+			Name:    "production",
+			Enabled: false,
+			Context: "",
+		})
+	}
+
+	return pipelineCRD
+}

--- a/cmd/dashboard/dashboard.go
+++ b/cmd/dashboard/dashboard.go
@@ -1,0 +1,29 @@
+package dashboard
+
+import (
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+// dashboardCmd represents the dashboard command
+var dashboardCmd = &cobra.Command{
+	Use:     "dashboard",
+	Aliases: []string{"db"},
+	Short:   "Opens the Kubero dashboard in your browser",
+	Long:    `Use the dashboard subcommand to open the Kubero dashboard in your browser.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		url := currentInstance.ApiUrl
+		openURLErr := browser.OpenURL(url)
+		if openURLErr != nil {
+			log.Fatal("Failed to open the browser:", openURLErr)
+			return
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dashboardCmd)
+}

--- a/cmd/down/down.go
+++ b/cmd/down/down.go
@@ -1,0 +1,73 @@
+package down
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// downCmd represents the down command
+var downCmd = &cobra.Command{
+	Use:     "down",
+	Aliases: []string{"undeploy", "dn"},
+	Short:   "Undeploy your pipelines and apps from the cluster",
+	Long: `Use the pipeline or app subcommand to undeploy your pipelines and apps from the cluster
+Subcommands:
+  kubero down [pipeline|app]`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if pipelineName != "" && appName == "" {
+			downPipeline()
+		} else if appName != "" {
+			downApp()
+		} else {
+			downAllPipelines()
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(downCmd)
+	downCmd.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "name of the pipeline")
+	downCmd.Flags().StringVarP(&stageName, "stage", "s", "", "Name of the stage [test|stage|production]")
+	downCmd.Flags().StringVarP(&appName, "app", "a", "", "name of the app")
+	downCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "Skip asking for confirmation")
+}
+
+func downPipeline() {
+	pipelinesList := getAllRemotePipelines()
+	ensurePipelineIsSet(pipelinesList)
+	downPipelineByName(pipelineName)
+}
+
+func downPipelineByName(pipelineName string) {
+	confirmationLine("Are you sure you want to undeploy the pipeline '"+pipelineName+"'?", "y")
+
+	_, err := api.UnDeployPipeline(pipelineName)
+	if err != nil {
+		panic("Unable to undeploy Pipeline")
+	}
+}
+
+func downApp() {
+
+	pipelinesList := getAllRemotePipelines()
+	ensurePipelineIsSet(pipelinesList)
+
+	ensureStageNameIsSet()
+
+	appsList := getAllRemoteApps()
+	ensureAppNameIsSelected(appsList)
+
+	confirmationLine("Are you sure you want to undeploy the app "+appName+" from "+stageName+" in "+pipelineName+"?", "y")
+
+	_, err := api.UnDeployApp(pipelineName, stageName, appName)
+	if err != nil {
+		panic("Unable to undeploy App")
+	}
+}
+
+func downAllPipelines() {
+	confirmationLine("Are you sure you want to undeploy all pipelines?", "y")
+	pipelinesList := getAllLocalPipelines()
+	for _, pipeline := range pipelinesList {
+		downPipelineByName(pipeline)
+	}
+}

--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -1,0 +1,130 @@
+package fetch
+
+import (
+	"encoding/json"
+	"fmt"
+	"kubero/pkg/kuberoApi"
+	"os"
+
+	"github.com/i582/cfmt/cmd/cfmt"
+	"github.com/spf13/cobra"
+)
+
+// fetchCmd represents the fetch command
+var fetchCmd = &cobra.Command{
+	Use:     "fetch",
+	Aliases: []string{"pull", "fe"},
+	Short:   "Fetch your remote pipelines and apps to your local repository",
+	Long:    `Use the pipeline or app subcommand to fetch your pipelines and apps to your local repository`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if pipelineName != "" && appName == "" {
+			fetchPipeline(pipelineName)
+		} else if pipelineName != "" && appName != "" {
+			ensureStageNameIsSet()
+			fetchPipeline(pipelineName)
+			fetchApp(appName, stageName, pipelineName)
+		} else {
+			fetchAllPipelines()
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+	fetchCmd.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "Name of the pipeline")
+	fetchCmd.Flags().StringVarP(&stageName, "stage", "s", "", "Name of the stage [test|stage|production]")
+	fetchCmd.Flags().StringVarP(&appName, "app", "a", "", "Name of the app")
+}
+
+func fetchPipeline(pipelineName string) {
+	confirmation := promptLine("Do you want to fetch the pipeline '"+pipelineName+"'?", "[y,n]", "y")
+	if confirmation == "y" {
+		_, _ = cfmt.Println("{{Fetching pipeline}}::yellow " + pipelineName)
+
+		var pipeline kuberoApi.PipelineCRD
+
+		pipeline.APIVersion = "application.kubero.dev/v1alpha1"
+		pipeline.Kind = "KuberoPipeline"
+		pipeline.Spec.Name = pipelineName
+		pipeline.Metadata.Name = appName
+
+		p, pipelineErr := api.GetPipeline(pipelineName)
+
+		if pipelineErr != nil {
+			if p == nil {
+				_, _ = cfmt.Println("{{ERROR:}}::red Pipeline '" + pipelineName + "' not found ")
+				os.Exit(1)
+			}
+			if p.StatusCode() == 404 {
+				_, _ = cfmt.Println("{{ERROR:}}::red Pipeline '" + pipelineName + "' not found ")
+				os.Exit(1)
+			}
+			fmt.Println(pipelineErr)
+			os.Exit(1)
+		}
+
+		jsonUnmarshalErr := json.Unmarshal(p.Body(), &pipeline.Spec)
+		if jsonUnmarshalErr != nil {
+			fmt.Println(jsonUnmarshalErr)
+			return
+		}
+		writePipelineYaml(pipeline)
+
+	} else {
+		return
+	}
+}
+
+func fetchApp(appName string, stageName string, pipelineName string) {
+
+	confirmation := promptLine("Do you want to fetch the app '"+appName+"' from '"+pipelineName+"'?", "[y,n]", "y")
+	if confirmation == "y" {
+		_, _ = cfmt.Println("{{Fetching app}}::yellow " + appName + "")
+	} else {
+		_, _ = cfmt.Println("{{Aborted}}::red")
+		return
+	}
+
+	var app kuberoApi.AppCRD
+	app.APIVersion = "application.kubero.dev/v1alpha1"
+	app.Kind = "KuberoApp"
+
+	app.Spec.Pipeline = pipelineName
+	app.Spec.Phase = stageName
+	app.Spec.Name = appName
+	app.Metadata.Name = appName
+
+	a, appErr := api.GetApp(pipelineName, stageName, appName)
+
+	if appErr != nil {
+		if a == nil {
+			_, _ = cfmt.Println("{{ERROR:}}::red App '" + appName + "' not found ")
+			os.Exit(1)
+		}
+		if a.StatusCode() == 404 {
+			_, _ = cfmt.Println("{{ERROR:}}::red App '" + appName + "' not found ")
+			os.Exit(1)
+		}
+		fmt.Println(appErr)
+		os.Exit(1)
+	}
+
+	jsonUnmarshalErr := json.Unmarshal(a.Body(), &app)
+	if jsonUnmarshalErr != nil {
+		fmt.Println(jsonUnmarshalErr)
+		return
+	}
+
+	writeAppYaml(app)
+
+}
+
+func fetchAllPipelines() {
+	confirmation := promptLine("Are you sure you want to fetch all pipelines?", "[y,n]", "n")
+	if confirmation == "y" {
+		_, _ = cfmt.Println("{{Fetching all pipelines}}::yellow")
+	} else {
+		_, _ = cfmt.Println("{{Aborted}}::red")
+		return
+	}
+}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -1,0 +1,125 @@
+package install
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/zalando/go-keyring"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	keySize       = 2048
+	keyringService = "kubero-cli"
+	keyringUser    = "kubero"
+)
+
+// InstallCmd represents the install command
+type InstallCmd struct {
+	// Add fields as needed
+}
+
+// NewInstallCmd creates a new InstallCmd
+func NewInstallCmd() *InstallCmd {
+	return &InstallCmd{}
+}
+
+// Execute runs the install command
+func (cmd *InstallCmd) Execute() error {
+	privateKey, publicKey, err := generateRSAKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate RSA key pair: %w", err)
+	}
+
+	password, err := generateRandomPassword()
+	if err != nil {
+		return fmt.Errorf("failed to generate random password: %w", err)
+	}
+
+	err = storePasswordInKeyring(password)
+	if err != nil {
+		return fmt.Errorf("failed to store password in keyring: %w", err)
+	}
+
+	err = savePrivateKeyToFile(privateKey, password)
+	if err != nil {
+		return fmt.Errorf("failed to save private key to file: %w", err)
+	}
+
+	err = savePublicKeyToFile(publicKey)
+	if err != nil {
+		return fmt.Errorf("failed to save public key to file: %w", err)
+	}
+
+	fmt.Println("Installation completed successfully.")
+	return nil
+}
+
+func generateRSAKeyPair() (*rsa.PrivateKey, ssh.PublicKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return privateKey, publicKey, nil
+}
+
+func generateRandomPassword() (string, error) {
+	const passwordLength = 16
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	password := make([]byte, passwordLength)
+	_, err := rand.Read(password)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range password {
+		password[i] = charset[int(password[i])%len(charset)]
+	}
+
+	return string(password), nil
+}
+
+func storePasswordInKeyring(password string) error {
+	return keyring.Set(keyringService, keyringUser, password)
+}
+
+func savePrivateKeyToFile(privateKey *rsa.PrivateKey, password string) error {
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+
+	privateKeyFile, err := os.Create("private_key.pem")
+	if err != nil {
+		return err
+	}
+	defer privateKeyFile.Close()
+
+	return pem.Encode(privateKeyFile, privateKeyBlock)
+}
+
+func savePublicKeyToFile(publicKey ssh.PublicKey) error {
+	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
+
+	publicKeyFile, err := os.Create("public_key.pub")
+	if err != nil {
+		return err
+	}
+	defer publicKeyFile.Close()
+
+	_, err = publicKeyFile.Write(publicKeyBytes)
+	return err
+}

--- a/cmd/instance/instance.go
+++ b/cmd/instance/instance.go
@@ -1,0 +1,105 @@
+package instance
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/i582/cfmt/cmd/cfmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// instanceCmd represents the instance command
+var instanceCmd = &cobra.Command{
+	Use:     "instance",
+	Aliases: []string{"i"},
+	Short:   "List available instances",
+	Long:    `Print a list of available instances.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		printInstanceList()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(instanceCmd)
+}
+
+func printInstanceList() {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Active", "Token", "Name", "API URL", "Path", "IAC Base Dir"})
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetRowLine(true)
+	table.SetCenterSeparator("")
+	table.SetBorder(false)
+	table.SetTablePadding("\t")
+	table.SetNoWhiteSpace(true)
+	for _, instanceName := range instanceNameList {
+		active := ""
+		if instanceName == currentInstanceName {
+			active = cfmt.Sprintf("   {{✔}}::green")
+		}
+
+		token := ""
+
+		if credentialsConfig.GetString(instanceName) != "" {
+			token = cfmt.Sprintf("  {{✔}}::green")
+		}
+
+		table.Append([]string{
+			active,
+			token,
+			instanceName,
+			instanceList[instanceName].ApiUrl,
+			instanceList[instanceName].ConfigPath,
+			instanceList[instanceName].IacBaseDir,
+		})
+	}
+	table.Render()
+}
+
+func createInstanceForm() {
+	fmt.Println("Create a new instance")
+
+	instanceName := promptLine("Enter the name of the instance", "", "")
+	instanceApiurl := promptLine("Enter the API URL of the instance", "", "http://localhost:80")
+	instancePath := viper.ConfigFileUsed()
+
+	personalInstanceList := viper.GetStringMap("instances")
+
+	personalInstanceList[instanceName] = Instance{
+		Name:       instanceName,
+		ApiUrl:     instanceApiurl,
+		ConfigPath: instancePath,
+	}
+
+	viper.Set("instances", personalInstanceList)
+
+	instanceNameList = append(instanceNameList, instanceName)
+
+	setCurrentInstance(instanceName)
+}
+
+func setCurrentInstance(instanceName string) {
+	currentInstanceName = instanceName
+	currentInstance = instanceList[instanceName]
+	viper.Set("currentInstance", instanceName)
+	writeConfigErr := viper.WriteConfig()
+	if writeConfigErr != nil {
+		fmt.Println("Failed to save configuration:", writeConfigErr)
+		return
+	}
+}
+
+func deleteInstanceForm() {
+	instanceName := selectFromList("Select an instance to delete", instanceNameList, "")
+
+	delete(instanceList, instanceName)
+	viper.Set("instances", instanceList)
+	writeConfigErr := viper.WriteConfig()
+	if writeConfigErr != nil {
+		fmt.Println("Failed to save configuration:", writeConfigErr)
+		return
+	}
+}

--- a/cmd/internal/loadAppConfig.go
+++ b/cmd/internal/loadAppConfig.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"log"
+
+	"github.com/spf13/viper"
+)
+
+func loadAppConfig(pipelineName string, stageName string, appName string) *viper.Viper {
+
+	baseDir := getIACBaseDir()
+	dir := baseDir + "/" + pipelineName + "/" + stageName
+
+	appConfig := viper.New()
+	appConfig.SetConfigName(appName)
+	appConfig.SetConfigType("yaml")
+	appConfig.AddConfigPath(dir)
+	readInConfigErr := appConfig.ReadInConfig()
+	if readInConfigErr != nil {
+		log.Fatal(readInConfigErr)
+		return nil
+	}
+
+	return appConfig
+}

--- a/cmd/internal/loadLocalApp.go
+++ b/cmd/internal/loadLocalApp.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"log"
+
+	"github.com/spf13/viper"
+	"kubero/pkg/kuberoApi"
+)
+
+func loadLocalApp(pipelineName string, stageName string, appName string) kuberoApi.AppCRD {
+
+	appConfig := loadAppConfig(pipelineName, stageName, appName)
+
+	var appCRD kuberoApi.AppCRD
+
+	appConfigUnmarshalErr := appConfig.Unmarshal(&appCRD)
+	if appConfigUnmarshalErr != nil {
+		log.Fatal(appConfigUnmarshalErr)
+		return kuberoApi.AppCRD{}
+	}
+
+	return appCRD
+}

--- a/cmd/kuberoCli/install.go
+++ b/cmd/kuberoCli/install.go
@@ -21,6 +21,12 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/tools/clientcmd"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"github.com/zalando/go-keyring"
+	"golang.org/x/crypto/ssh"
 )
 
 // installCmd represents the install command
@@ -1137,4 +1143,68 @@ type StorageClassesList struct {
 		ResourceVersion string `json:"resourceVersion"`
 		SelfLink        string `json:"selfLink"`
 	} `json:"metadata"`
+}
+
+func generateRSACertificates() {
+	fmt.Println("Generating RSA certificates...")
+
+	// Generate RSA key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	// Encode private key to PEM format
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	// Generate random password
+	password := generateRandomPassword(16)
+
+	// Store password in keyring
+	err = keyring.Set("kubero-cli", "rsa-password", password)
+	if err != nil {
+		log.Fatalf("Failed to store password in keyring: %v", err)
+	}
+
+	// Encrypt private key with password
+	encryptedPrivateKeyPEM, err := x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", privateKeyPEM, []byte(password), x509.PEMCipherAES256)
+	if err != nil {
+		log.Fatalf("Failed to encrypt private key: %v", err)
+	}
+
+	// Save encrypted private key to file
+	err = os.WriteFile("id_rsa", pem.EncodeToMemory(encryptedPrivateKeyPEM), 0600)
+	if err != nil {
+		log.Fatalf("Failed to save private key: %v", err)
+	}
+
+	// Generate public key
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		log.Fatalf("Failed to generate public key: %v", err)
+	}
+
+	// Save public key to file
+	err = os.WriteFile("id_rsa.pub", ssh.MarshalAuthorizedKey(publicKey), 0644)
+	if err != nil {
+		log.Fatalf("Failed to save public key: %v", err)
+	}
+
+	fmt.Println("RSA certificates generated successfully.")
+}
+
+func generateRandomPassword(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	password := make([]byte, length)
+	for i := range password {
+		randomIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			log.Fatalf("Failed to generate random password: %v", err)
+		}
+		password[i] = charset[randomIndex.Int64()]
+	}
+	return string(password)
 }

--- a/cmd/kuberoCli/test.go
+++ b/cmd/kuberoCli/test.go
@@ -1,0 +1,99 @@
+package kuberoCli
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/zalando/go-keyring"
+	"golang.org/x/crypto/ssh"
+	"github.com/spf13/cobra"
+)
+
+// testCmd represents the test command
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Run tests and generate RSA certificates",
+	Long:  `This command runs tests and generates encrypted RSA certificates with random passwords stored in a keyring.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runTests()
+		generateRSACertificates()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(testCmd)
+}
+
+func runTests() {
+	fmt.Println("Running tests...")
+	// Add your test logic here
+}
+
+func generateRSACertificates() {
+	fmt.Println("Generating RSA certificates...")
+
+	// Generate RSA key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	// Encode private key to PEM format
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	// Generate random password
+	password := generateRandomPassword(16)
+
+	// Store password in keyring
+	err = keyring.Set("kubero-cli", "rsa-password", password)
+	if err != nil {
+		log.Fatalf("Failed to store password in keyring: %v", err)
+	}
+
+	// Encrypt private key with password
+	encryptedPrivateKeyPEM, err := x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", privateKeyPEM, []byte(password), x509.PEMCipherAES256)
+	if err != nil {
+		log.Fatalf("Failed to encrypt private key: %v", err)
+	}
+
+	// Save encrypted private key to file
+	err = os.WriteFile("id_rsa", pem.EncodeToMemory(encryptedPrivateKeyPEM), 0600)
+	if err != nil {
+		log.Fatalf("Failed to save private key: %v", err)
+	}
+
+	// Generate public key
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		log.Fatalf("Failed to generate public key: %v", err)
+	}
+
+	// Save public key to file
+	err = os.WriteFile("id_rsa.pub", ssh.MarshalAuthorizedKey(publicKey), 0644)
+	if err != nil {
+		log.Fatalf("Failed to save public key: %v", err)
+	}
+
+	fmt.Println("RSA certificates generated successfully.")
+}
+
+func generateRandomPassword(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	password := make([]byte, length)
+	for i := range password {
+		randomIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			log.Fatalf("Failed to generate random password: %v", err)
+		}
+		password[i] = charset[randomIndex.Int64()]
+	}
+	return string(password)
+}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -1,0 +1,78 @@
+package up
+
+import (
+	"github.com/i582/cfmt/cmd/cfmt"
+	"github.com/spf13/cobra"
+)
+
+// upCmd represents the up command
+var upCmd = &cobra.Command{
+	Use:     "up",
+	Aliases: []string{"deploy", "dp"},
+	Short:   "Deploy your pipelines and apps to the cluster",
+	Long:    ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		if pipelineName != "" && appName == "" {
+
+			pipelinesList := getAllLocalPipelines()
+			ensurePipelineIsSet(pipelinesList)
+			upPipeline()
+		} else if appName != "" {
+
+			pipelinesList := getAllLocalPipelines()
+			ensurePipelineIsSet(pipelinesList)
+			upApp()
+		} else {
+			upAllPipelines()
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(upCmd)
+	upCmd.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "name of the pipeline")
+	upCmd.Flags().StringVarP(&stageName, "stage", "s", "", "Name of the stage [test|stage|production]")
+	upCmd.Flags().StringVarP(&appName, "app", "a", "", "name of the app")
+	upCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "Skip asking for confirmation")
+}
+
+func upPipeline() {
+	confirmationLine("Are you sure you want to deploy the pipeline '"+pipelineName+"'?", "y")
+
+	pipeline := loadLocalPipeline(pipelineName)
+	_, deployPipelineErr := api.DeployPipeline(pipeline)
+	if deployPipelineErr != nil {
+		_, _ = cfmt.Println("{{Error deploying pipeline}}::red", deployPipelineErr)
+		return
+	}
+}
+
+func upApp() {
+	confirmationLine("Are you sure you want to deploy the app "+appName+" to "+pipelineName+"?", "y")
+	app := loadLocalApp(pipelineName, stageName, appName)
+	app.Spec.Pipeline = pipelineName             // ensure pipeline is set
+	app.Spec.Phase = stageName                   // ensure stage is set
+	app.Spec.Security.VulnerabilityScans = false // TODO: ask for this
+	_, DeployAppErr := api.DeployApp(app)
+	if DeployAppErr != nil {
+		_, _ = cfmt.Println("{{Error deploying app}}::red", DeployAppErr)
+		return
+	}
+}
+
+func upAllPipelines() {
+
+	confirmationLine("Are you sure you want to deploy all pipelines?", "y")
+	pipelinesConfigs := loadAllLocalPipelines()
+
+	_, _ = cfmt.Println("{{Deploying all pipelines}}::yellow")
+
+	for _, pipelineCRD := range pipelinesConfigs {
+		_, _ = cfmt.Println("{{Deploying pipeline}}::yellow " + pipelineCRD.Spec.Name + "")
+		_, deployPipelineErr := api.DeployPipeline(pipelineCRD)
+		if deployPipelineErr != nil {
+			_, _ = cfmt.Println("{{Error deploying pipeline}}::red", deployPipelineErr)
+			return
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
+	github.com/zalando/go-keyring v0.2.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12


### PR DESCRIPTION
This pull request includes several significant changes to the `kubero` CLI tool, including the addition of new commands, improvements to existing functionality, and updates to documentation. Below is a summary of the most important changes grouped by theme:

### New Commands:
* [`cmd/config/config.go`](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68R1-R26): Introduced the `config` command to show user configuration.
* [`cmd/create/create.go`](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R1-R282): Added the `create` command to initiate new pipelines and apps.
* [`cmd/dashboard/dashboard.go`](diffhunk://#diff-fe2ad8f265e251c2cedab4995184c4f619fc19efc1e3c5cf59275f11fce0f7a7R1-R29): Added the `dashboard` command to open the Kubero dashboard in a browser.
* [`cmd/down/down.go`](diffhunk://#diff-ee2711538f13c0e8c8836b35c1669383bd48165b23ca674291581ea3fad20f2fR1-R73): Added the `down` command to undeploy pipelines and apps.
* [`cmd/fetch/fetch.go`](diffhunk://#diff-a310c490113bf695d3dd75cf36646d642c4f1f63426b3641e183918ed37aac12R1-R130): Added the `fetch` command to fetch remote pipelines and apps to the local repository.
* [`cmd/install/install.go`](diffhunk://#diff-b105e0fd290117fe4056a1e2270006e9ea7a6025f5b57936dff42d50660e0b9cR1-R125): Added the `install` command for automated RSA certificate generation and storage.
* [`cmd/instance/instance.go`](diffhunk://#diff-83bc4a9f4e4ddcedfb5ca8f92f6e9c2ee1c6520f897e02f0a0760513b5aefe85R1-R105): Added the `instance` command to list and manage instances.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R43): Updated to include information on automated RSA certificate generation and separate test flow handling.

### Build and Test Enhancements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R62-R69): Added a `test` target to run tests and updated the `help` target to include the new `test` command. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R62-R69) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R82)

### Internal Configuration Loading:
* [`cmd/internal/loadAppConfig.go`](diffhunk://#diff-b4b2a678d0a2df9151121dde13b5520df3237f888db80aa8135e944701ea1bd9R1-R25): Added a function to load application configuration from YAML files.