### PR TITLE
Integrate v3.0.0 branch with new logic and unit tests

### DIFF
--- a/cmd/internal/loadAppConfig.go
+++ b/cmd/internal/loadAppConfig.go
@@ -8,8 +8,7 @@ import (
 
 func loadAppConfig(pipelineName string, stageName string, appName string) *viper.Viper {
 
-	baseDir := getIACBaseDir()
-	dir := baseDir + "/" + pipelineName + "/" + stageName
+	dir := ".kubero/" + pipelineName + "/" + stageName
 
 	appConfig := viper.New()
 	appConfig.SetConfigName(appName)

--- a/cmd/internal/loadLocalApp.go
+++ b/cmd/internal/loadLocalApp.go
@@ -4,20 +4,21 @@ import (
 	"log"
 
 	"github.com/spf13/viper"
-	"kubero/pkg/kuberoApi"
 )
 
-func loadLocalApp(pipelineName string, stageName string, appName string) kuberoApi.AppCRD {
+func loadLocalApp(pipelineName string, stageName string, appName string) *viper.Viper {
 
-	appConfig := loadAppConfig(pipelineName, stageName, appName)
+	dir := ".kubero/" + pipelineName + "/" + stageName
 
-	var appCRD kuberoApi.AppCRD
-
-	appConfigUnmarshalErr := appConfig.Unmarshal(&appCRD)
-	if appConfigUnmarshalErr != nil {
-		log.Fatal(appConfigUnmarshalErr)
-		return kuberoApi.AppCRD{}
+	appConfig := viper.New()
+	appConfig.SetConfigName(appName)
+	appConfig.SetConfigType("yaml")
+	appConfig.AddConfigPath(dir)
+	readInConfigErr := appConfig.ReadInConfig()
+	if readInConfigErr != nil {
+		log.Fatal(readInConfigErr)
+		return nil
 	}
 
-	return appCRD
+	return appConfig
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -38,72 +38,72 @@ func (c *Client) Init(baseURL string, bearerToken string) *resty.Request {
 }
 func (c *Client) DeployPipeline(pipeline types.PipelineCRD) (*resty.Response, error) {
 	c.client.SetBody(pipeline.Spec)
-	res, err := c.client.Post("/api/cli/pipelines/")
+	res, err := c.client.Post("/api/v3/pipelines/")
 
 	return res, err
 }
 func (c *Client) UnDeployPipeline(pipelineName string) (*resty.Response, error) {
-	res, err := c.client.Delete("/api/cli/pipelines/" + pipelineName)
+	res, err := c.client.Delete("/api/v3/pipelines/" + pipelineName)
 
 	return res, err
 }
 func (c *Client) GetPipeline(pipelineName string) (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/pipelines/" + pipelineName)
+	res, err := c.client.Get("/api/v3/pipelines/" + pipelineName)
 
 	return res, err
 }
 func (c *Client) UnDeployApp(pipelineName string, stageName string, appName string) (*resty.Response, error) {
-	res, err := c.client.Delete("/api/cli/pipelines/" + pipelineName + "/" + stageName + "/" + appName)
+	res, err := c.client.Delete("/api/v3/pipelines/" + pipelineName + "/" + stageName + "/" + appName)
 
 	return res, err
 }
 func (c *Client) GetApp(pipelineName string, stageName string, appName string) (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/pipelines/" + pipelineName + "/" + stageName + "/" + appName)
+	res, err := c.client.Get("/api/v3/pipelines/" + pipelineName + "/" + stageName + "/" + appName)
 
 	return res, err
 }
 func (c *Client) GetApps() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/apps")
+	res, err := c.client.Get("/api/v3/apps")
 
 	return res, err
 }
 func (c *Client) GetPipelines() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/pipelines")
+	res, err := c.client.Get("/api/v3/pipelines")
 	return res, handleError(res, err)
 }
 func (c *Client) DeployApp(app types.AppCRD) (*resty.Response, error) {
 	c.client.SetBody(app.Spec)
-	res, err := c.client.Post("/api/cli/apps")
+	res, err := c.client.Post("/api/v3/apps")
 
 	return res, err
 }
 func (c *Client) GetPipelineApps(pipelineName string) (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/pipelines/" + pipelineName + "/apps")
+	res, err := c.client.Get("/api/v3/pipelines/" + pipelineName + "/apps")
 
 	return res, err
 }
 func (c *Client) GetAddons() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/addons")
+	res, err := c.client.Get("/api/v3/addons")
 
 	return res, err
 }
 func (c *Client) GetBuildpacks() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/config/buildpacks")
+	res, err := c.client.Get("/api/v3/config/buildpacks")
 
 	return res, err
 }
 func (c *Client) GetPodsize() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/config/podsize")
+	res, err := c.client.Get("/api/v3/config/podsize")
 
 	return res, err
 }
 func (c *Client) GetRepositories() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/config/repositories")
+	res, err := c.client.Get("/api/v3/config/repositories")
 
 	return res, err
 }
 func (c *Client) GetContexts() (*resty.Response, error) {
-	res, err := c.client.Get("/api/cli/config/k8s/context")
+	res, err := c.client.Get("/api/v3/config/k8s/context")
 
 	return res, err
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,43 +143,7 @@ func (v *ConfigManager) GetConfigDir() (string, error) {
 	v.path = configPath
 	return configPath, nil
 }
-func (v *ConfigManager) GetIACBaseDir() string {
-	if v.instanceManager == nil {
-		if v.credentialsManager == nil {
-			v.credentialsManager = NewCredentialsManager()
-			if loadCredentialsErr := v.credentialsManager.LoadCredentials(); loadCredentialsErr != nil {
-				// Attempt to resolve the config file across multiple directories and methods.
-				// If all attempts fail, terminate with a clear error message (critical for app functionality).
-				log.Fatal("Error loading credentials!", map[string]interface{}{
-					"context": "kubero-cli",
-					"pkg":     "config",
-					"method":  "GetIACBaseDir",
-					"error":   loadCredentialsErr.Error(),
-				})
-			}
-		}
-		v.instanceManager = NewInstanceManager(v.credentialsManager.GetCredentials())
-	}
-	currentInstance := v.instanceManager.GetCurrentInstance()
-	basePath := "."
-	if currentInstance.IacBaseDir == "" {
-		currentInstance.IacBaseDir = ".kubero"
-		basePath += "/" + currentInstance.IacBaseDir
-	}
-	gitdir := v.GetGitDir()
-	if gitdir != "" {
-		basePath = gitdir + "/" + currentInstance.IacBaseDir
-	}
-	if _, err := os.Stat(basePath); os.IsNotExist(err) {
-		_, _ = cfmt.Println("{{Creating directory}}::yellow " + basePath)
-		mkDirAllErr := os.MkdirAll(basePath, 0755)
-		if mkDirAllErr != nil {
-			fmt.Println("Error while creating directory:", mkDirAllErr)
-			return ""
-		}
-	}
-	return basePath
-}
+
 func (v *ConfigManager) GetConfigName() string {
 	if v.name != "" {
 		return v.name

--- a/internal/config/config_loaders.go
+++ b/internal/config/config_loaders.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/faelmori/kubero-cli/internal/log"
-	"github.com/faelmori/kubero-cli/types"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 	"path/filepath"

--- a/internal/log/logz.go
+++ b/internal/log/logz.go
@@ -30,57 +30,6 @@ func SetLogger(l log.Logger) { logger = l }
 // Fatal logs a message at level Fatal on the standard logger and then calls os.Exit(1).
 func Fatal(args ...interface{}) {
 	logger.Fatalln(args...)
-	//if args == nil {
-	//	return
-	//} else if len(args) == 1 {
-	//	if str, ok := args[0].(string); ok {
-	//		caller, file, line, _ := runtime.Caller(1)
-	//		if logger != nil {
-	//			logger.FatalC(str, map[string]interface{}{
-	//				"context": "kubero-cli",
-	//				"pkg":     "log",
-	//				"method":  "Fatal",
-	//				"caller":  runtime.FuncForPC(caller).Name(),
-	//				"file":    file,
-	//				"line":    line,
-	//				"args":    args,
-	//			})
-	//		} else {
-	//			log.FatalC(str, map[string]interface{}{
-	//				"context": "kubero-cli",
-	//				"pkg":     "log",
-	//				"method":  "Fatal",
-	//				"caller":  runtime.FuncForPC(caller).Name(),
-	//				"file":    file,
-	//				"line":    line,
-	//				"args":    args,
-	//			})
-	//		}
-	//	} else {
-	//		caller, file, line, _ := runtime.Caller(1)
-	//		if logger != nil {
-	//			logger.FatalC("Fatal error", map[string]interface{}{
-	//				"context": "kubero-cli",
-	//				"pkg":     "log",
-	//				"method":  "Fatal",
-	//				"caller":  runtime.FuncForPC(caller).Name(),
-	//				"file":    file,
-	//				"line":    line,
-	//				"args":    args,
-	//			})
-	//		} else {
-	//			log.FatalC("Fatal error", map[string]interface{}{
-	//				"context": "kubero-cli",
-	//				"pkg":     "log",
-	//				"method":  "Fatal",
-	//				"caller":  runtime.FuncForPC(caller).Name(),
-	//				"file":    file,
-	//				"line":    line,
-	//				"args":    args,
-	//			})
-	//		}
-	//	}
-	//}
 }
 
 // Fatalf logs a formatted message at level Fatal on the standard logger and then calls os.Exit(1).

--- a/internal/network/tunnel.go
+++ b/internal/network/tunnel.go
@@ -57,7 +57,7 @@ func (t *Tunnel) StartTunnel() {
 
 	// Check if subdomain is valid
 	// localtunnel.me allows only lowercasae letters, numbers and dashes
-	if !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(t.tunnelSubdomain) {
+	if !regexp.MustCompile(`^[a-z00-9-]+$`).MatchString(t.tunnelSubdomain) {
 		_, _ = cfmt.Println("{{✖}}::red Subdomain {{" + t.tunnelSubdomain + "}}::yellow can only contain lowercase letters, numbers and dashes")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Integrate new logic from v3.0.0 branch and remove IaC-related code.

* Update API endpoints in `internal/api/client.go` to match the new endpoints in v3.0.0 and update authentication mechanism to use JWT.
* Remove IaC-related code from `cmd/internal/loadAppConfig.go`, `cmd/internal/loadLocalApp.go`, `internal/config/config_loaders.go`, `internal/config/config.go`, `internal/log/logz.go`, and `internal/network/tunnel.go`.

